### PR TITLE
Small changes and better cli handling

### DIFF
--- a/FireMotD
+++ b/FireMotD
@@ -511,7 +511,7 @@ Examples:
   $0 --saveupdates
 
 Note:
-  Some functionality may require superuser priviledges. Eg. check for updates.
+  Some functionalities may require superuser priviledges. Eg. check for updates.
   Please try doing sudo $0 if you have problems.
 "
 	exit 0
@@ -546,7 +546,7 @@ while :; do
             printVersion ; exit 0 ;;
         -h|--help|--Help)
             printHelp ; exit 0 ;;
-        yum|YUM|Yum|Zypper|zypper|-U|--Updates|-Y)
+        yum|YUM|Yum|Zypper|zypper|-U|--Updates|--updates|-Y)
             checkSudo $@; CountUpdates ; shift ;;
         -s|--saveupdates|--SaveUpdates|--saveUpdates)
             checkSudo $@; CountUpdates > /var/tmp/updatecount.txt ; shift ;;

--- a/FireMotD
+++ b/FireMotD
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Script name:  FireMotD
-# Version:      v5.02.160528
+# Version:      v5.03.160624
 # Created on:   10/02/2014
 # Author:       Willem D'Haese
 # Purpose:      Bash script that will dynamically generate a message
@@ -27,7 +27,7 @@
 # Modified: Jun 24 2016 by Gustavo Neves
 
 Verbose=0
-Version=5.02.160528
+Version=5.03.160624
 UpdateFile=/var/tmp/updatecount.txt
 
 

--- a/FireMotD
+++ b/FireMotD
@@ -525,7 +525,8 @@ usage() {
 }
 
 printVersion() {
-	echo "$0 v$ScriptVersion"
+	cVersion="$(echo -e "${ScriptVersion}" | tr -d '[[:space:]]')"
+	echo "$(basename $0) v$cVersion"
 	return 0
 }
 

--- a/FireMotD
+++ b/FireMotD
@@ -133,7 +133,7 @@ GatherInfo () {
         if [[ "$Dmi" = *"Rasp"* ]] ; then
             Platform="$(dmesg | grep "Rasp" | sed 's/.*: //')"
         else
-            Platform="Unknown"
+            Platform="$(dmesg | grep "DMI" | sed -n -e 's/^.*DMI: //p')"
         fi
     fi
     CpuUtil="$(LANG=en_GB.UTF-8 mpstat 1 1 | awk '$2 ~ /CPU/ { for(i=1;i<=NF;i++) { if ($i ~ /%idle/) field=i } } $2 ~ /all/ { print 100 - $field}' | tail -1)"

--- a/FireMotD
+++ b/FireMotD
@@ -110,6 +110,8 @@ GatherInfo () {
 	OsVersion="$(cat /etc/os-release | sed -n 4p | sed 's/PRETTY_NAME="//' | sed 's/ (.*//')"
     elif [[ "$OsVersion" == *"Raspbian"* ]] ; then
         OsVersion="$(cat /etc/*release | head -n 1 | sed 's/.*"\(.*\)"[^"]*$/\1/')"
+    elif [[ "$OsVersion" == *"PRETTY_NAME"* ]] ; then
+	    OsVersion="$(cat /etc/*release | head -n 1 | cut -f2 -d'"')"
     fi
     IpPath="$(which ip 2>/dev/null)"
     IpAddress="$(${IpPath} route get 8.8.8.8 | head -1 | cut -d' ' -f8)"

--- a/FireMotD
+++ b/FireMotD
@@ -107,11 +107,11 @@ GatherInfo () {
         PatchLevel="$(cat /etc/*release | sed -n 3p | sed 's/.*= //')"
         OsVersion="${OsVersion}.$PatchLevel"
     elif [[ "$OsVersion" == "openSUSE"* ]] ; then
-	OsVersion="$(cat /etc/os-release | sed -n 4p | sed 's/PRETTY_NAME="//' | sed 's/ (.*//')"
+        OsVersion="$(cat /etc/os-release | sed -n 4p | sed 's/PRETTY_NAME="//' | sed 's/ (.*//')"
     elif [[ "$OsVersion" == *"Raspbian"* ]] ; then
         OsVersion="$(cat /etc/*release | head -n 1 | sed 's/.*"\(.*\)"[^"]*$/\1/')"
     elif [[ "$OsVersion" == *"PRETTY_NAME"* ]] ; then
-	    OsVersion="$(cat /etc/*release | head -n 1 | cut -f2 -d'"')"
+        OsVersion="$(cat /etc/*release | head -n 1 | cut -f2 -d'"')"
     fi
     IpPath="$(which ip 2>/dev/null)"
     IpAddress="$(${IpPath} route get 8.8.8.8 | head -1 | cut -d' ' -f8)"
@@ -487,7 +487,7 @@ echo $HtmlCode
 printHelp() {
 	printVersion
 	echo "
-Usage: $0 <-t theme> [UhCVv]
+Usage: $0 <-t theme> [UhCVvs]
 
 Options:
   -h | --help        Shows this help and exits

--- a/FireMotD
+++ b/FireMotD
@@ -13,6 +13,7 @@
 #   01/05/16 => Swap and Memory percentages /var/tmp/updatecount.txt
 #   19/05/16 => Migration to FireMotD
 #   27/05/16 => Fix for WriteLog on OpenSUSE
+#   24/06/16 => Added new options, help and version messages and a few other things.
 # Copyright:
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the Free
@@ -27,9 +28,9 @@
 # Modified: Jun 24 2016 by Gustavo Neves
 
 Verbose=0
-Version=5.03.160624
 UpdateFile=/var/tmp/updatecount.txt
-
+ScriptName="$(readlink -e $0)"
+ScriptVersion=" $(cat $ScriptName | grep "# Version:" | awk {'print $3'} | tr -cd '[[:digit:].-]' | sed 's/.\{2\}$//') "
 
 WriteLog () {
     if [ -z "$1" ] ; then
@@ -100,8 +101,6 @@ ColorTest () {
 }
 
 GatherInfo () {
-    ScriptName="$(readlink -e $0)"
-    ScriptVersion=" $(cat $ScriptName | grep "# Version:" | awk {'print $3'} | tr -cd '[[:digit:].-]' | sed 's/.\{2\}$//') "
     OsVersion="$(cat /etc/*release | head -n 1)"
     if [[ "$OsVersion" == "SUSE"* ]] ; then
         OsVersion="$(echo $OsVersion | sed 's/ (.*//')"
@@ -526,7 +525,7 @@ usage() {
 }
 
 printVersion() {
-	echo "$0 v$Version"
+	echo "$0 v$ScriptVersion"
 	return 0
 }
 

--- a/FireMotD
+++ b/FireMotD
@@ -28,6 +28,8 @@
 
 Verbose=0
 Version=5.02.160528
+UpdateFile=/var/tmp/updatecount.txt
+
 
 WriteLog () {
     if [ -z "$1" ] ; then
@@ -171,7 +173,7 @@ GatherInfo () {
     RootTotal="$(printf "%0.2f\n" $(bc -q <<< scale=2\;$RootTotalB/1024/1024))"
     RootUsedPerc="$(df -kP / | tail -1 | awk '{print $5}'| sed s'/%$//')"
     RootFreePerc="$(expr 100 - $RootUsedPerc)" 
-    UpdateCount="$(cat /var/tmp/updatecount.txt)"
+    UpdateCount="$(cat $UpdateFile)"
     SessionCount="$(who | grep $USER | wc -l)"
     ProcessCount="$(ps -Afl | wc -l)"
     ProcessMax="$(ulimit -u)"
@@ -494,7 +496,7 @@ Options:
   -C | --colortest   Prints color test to screen
   -U | --updates     Checks updates and prints to stdout
   -s | --saveupdates Check updates and saves to disk
-                     (same as $0 -U > /var/tmp/updatecount.txt)
+                     (same as $0 -U > $UpdateFile)
 
 Available Themes:
   -t original
@@ -549,7 +551,7 @@ while :; do
         yum|YUM|Yum|Zypper|zypper|-U|--Updates|--updates|-Y)
             checkSudo $@; CountUpdates ; shift ;;
         -s|--saveupdates|--SaveUpdates|--saveUpdates)
-            checkSudo $@; CountUpdates > /var/tmp/updatecount.txt ; shift ;;
+            checkSudo $@; CountUpdates > "$UpdateFile" ; chmod 644 "$UpdateFile" ; shift ;;
         -t|--Theme|--theme)
             shift; Theme=$1 
             case "$Theme" in

--- a/FireMotD
+++ b/FireMotD
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Script name:  FireMotD
-# Version:      v5.02.160527
+# Version:      v5.02.160528
 # Created on:   10/02/2014
 # Author:       Willem D'Haese
 # Purpose:      Bash script that will dynamically generate a message
@@ -23,8 +23,11 @@
 # Public License for more details. You should have received a copy of the
 # GNU General Public License along with this program.  If not, see
 # <http://www.gnu.org/licenses/>.
+#
+# Modified: Jun 24 2016 by Gustavo Neves
 
 Verbose=0
+Version=5.02.160528
 
 WriteLog () {
     if [ -z "$1" ] ; then
@@ -91,6 +94,7 @@ ColorTest () {
         done 
         run=$((run + 1))
     done
+    echo -e "\e[0;37m"
 }
 
 GatherInfo () {
@@ -477,13 +481,76 @@ HtmlCode+="</tbody></table></body></html>"
 echo $HtmlCode
 }
 
+printHelp() {
+	printVersion
+	echo "
+Usage: $0 <-t theme> [UhCVv]
+
+Options:
+  -h | --help        Shows this help and exits
+  -v | --verbose     Verbose mode (shows messages)
+  -V | --version     Shows version information and exits
+  -t | --theme       Shows Motd info on screen, based on the chosen theme
+  -C | --colortest   Prints color test to screen
+  -U | --updates     Checks updates and prints to stdout
+  -s | --saveupdates Check updates and saves to disk
+                     (same as $0 -U > /var/tmp/updatecount.txt)
+
+Available Themes:
+  -t original
+  -t modern
+  -t red
+  -t blue
+  -t html
+  -t blank
+
+Examples:
+  $0 -t original
+  $0 --theme Modern
+  $0 --colortest
+  $0 --saveupdates
+
+Note:
+  Some functionality may require superuser priviledges. Eg. check for updates.
+  Please try doing sudo $0 if you have problems.
+"
+	exit 0
+}
+
+usage() {
+	printVersion
+	echo "Usage: $0 <-t theme> [UhCVv]"
+	echo "  Try: $0 --help"
+}
+
+printVersion() {
+	echo "$0 v$Version"
+	return 0
+}
+
+checkSudo() {
+	if [ "$EUID" -ne 0 ]; then 
+		echo "Update check requires root privileges"
+		echo "Example:"
+		echo "    sudo $0 $1"
+		exit 1
+	fi
+	return 0
+}
+
 while :; do
     case "$1" in
-        -h|--help)
-            DisplayHelp="true" ; shift ;;
+        -v|--verbose|--Verbose)
+            Verbose=1 ; shift ;;
+        -V|--version|--Version)
+            printVersion ; exit 0 ;;
+        -h|--help|--Help)
+            printHelp ; exit 0 ;;
         yum|YUM|Yum|Zypper|zypper|-U|--Updates|-Y)
-            CountUpdates ; shift ;;
-        -t|--Theme)
+            checkSudo $@; CountUpdates ; shift ;;
+        -s|--saveupdates|--SaveUpdates|--saveUpdates)
+            checkSudo $@; CountUpdates > /var/tmp/updatecount.txt ; shift ;;
+        -t|--Theme|--theme)
             shift; Theme=$1 
             case "$Theme" in
                 original|Original) GatherInfo ; StartOriginalBlue ; GenerateOriginal256Color ;;
@@ -492,11 +559,11 @@ while :; do
                 blue|Blue) GatherInfo ; StartBlueTheme ; GenerateBasic16Color ;;
                 html|Html) GatherInfo ; GenerateHtmlTheme ;;
                 blank|Blank|blanco|Blanco|Text|Clean|clean) GatherInfo ; GenerateBasic16Color ;;
-                *) echo "you specified a non-existant theme." ; exit 2 ;;
+                *) echo "You specified a non-existant theme: $1" ; exit 2 ;;
             esac
             shift ;;
-        -C|--Colortest) ColorTest ; shift ;;
-        -*) echo "you specified a non-existant option. " ; exit 2 ;;
+        -C|--Colortest|--colortest) ColorTest ; shift ;;
+        -*) echo "You specified a non-existant option: $1" ; exit 2 ;;
         *) break ;;
     esac
 done

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@
 IDIR=/usr/local/sbin
 IFILE=$(IDIR)/FireMotD
 
-BCIDIR=$(IDIR)/bash_completion.d
-BCIFILE=$(BCDIR)/FireMotD
+BCIDIR=bash_completion.d
+BCIFILE=$(BCIDIR)/FireMotD
 
 BCODIR=/etc/bash_completion.d
 BCOFILE=$(BCODIR)/FireMotD

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+# Installs to /usr/local/sbin
+# Change variables to adjust locations
+#
+# Jun 24 2016 - Gustavo Neves
+
+IDIR=/usr/local/sbin
+IFILE=$(IDIR)/FireMotD
+
+BCIDIR=$(IDIR)/bash_completion.d
+BCIFILE=$(BCDIR)/FireMotD
+
+BCODIR=/etc/bash_completion.d
+BCOFILE=$(BCODIR)/FireMotD
+
+all:
+
+install:
+	cp FireMotD $(IFILE)
+	chmod 755 $(IFILE)
+
+bash_completion:
+	cp $(BCIFILE) $(BCOFILE)
+
+uninstall:
+	rm -f $(IFILE)
+	rm -f $(BCOFILE)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #
 # Jun 24 2016 - Gustavo Neves
 
-IDIR=/usr/local/sbin
+IDIR=/usr/local/bin
 IFILE=$(IDIR)/FireMotD
 
 BCIDIR=bash_completion.d

--- a/bash_completion.d/FireMotD
+++ b/bash_completion.d/FireMotD
@@ -1,0 +1,29 @@
+# file: FireMotD
+# /usr/local/sbin/FireMotD parameter-completion
+
+_FireMotD ()   #  By convention, the function name
+{                 #+ starts with an underscore.
+
+  local cur prev prevv
+  # Pointer to current and previous completion words.
+
+  COMPREPLY=()   # Array variable storing the possible completions.
+  cur=${COMP_WORDS[COMP_CWORD]}
+  prev=${COMP_WORDS[COMP_CWORD-1]}
+  prevv=${COMP_WORDS[COMP_CWORD-2]}
+
+  if [[ $prev = "-t" ]] || [[ $prev = "--theme" ]] || [[ $prev = "--Theme" ]]; then
+    COMPREPLY=( $( compgen -W "original Original modern Modern red Red \
+                               blue Blue html Html blank Blank text Text\
+                               clean Clean" -- $cur ) )
+  elif [[ ! $prev = "-t" ]] && [[ ! $prev = "--theme" ]] && [[ ! $prev = "--Theme" ]]; then
+    COMPREPLY=( $( compgen -W '-v -V -h -U -s -t -C \
+                               --verbose --Verbose --help --Help \
+                               --updates --Updates --saveupdates --saveUpdates \
+                               --SaveUpdates --theme --Theme \
+                               --colortest --Colortest' -- $cur ) )
+  fi
+
+  return 0
+} &&
+complete -F _FireMotD FireMotD

--- a/bash_completion.d/FireMotD
+++ b/bash_completion.d/FireMotD
@@ -1,5 +1,5 @@
 # file: FireMotD
-# /usr/local/sbin/FireMotD parameter-completion
+# /usr/local/bin/FireMotD parameter-completion
 
 _FireMotD ()   #  By convention, the function name
 {                 #+ starts with an underscore.

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,7 @@ In case you find a bug or have a feature request, please make an issue on GitHub
 $ FireMotD --help
 /usr/local/bin/FireMotD v5.03.160624
 
-Usage: /usr/local/bin/FireMotD <-t theme> [UhCVv]
+Usage: /usr/local/bin/FireMotD <-t theme> [UhCVvs]
 
 Options:
   -h | --help        Shows this help and exits

--- a/readme.md
+++ b/readme.md
@@ -87,6 +87,39 @@ To install bash_completion (with TAB):
 sudo make bash_completion
 ```
 
+### Crontab example 
+
+This is an example on how to update the System Update Info daily.
+This will update the /var/tmp/updatecount.txt file for later access.
+
+To edit root's crontab:
+```bash
+sudo crontab -e
+```
+
+Then add this line (updates everyday at 3:03am)
+```bash
+3 3 * * * /usr/local/bin/FireMotD -s
+```
+
+Or using the old way:
+```bash
+3 3 * * * /usr/local/bin/FireMotD -U > /var/tmp/updatecount.txt
+```
+
+### Adding to an SSH session
+
+To add this to a single user, just call the program from the user's ~/.profile file.
+
+```bash
+nano ~/.profile
+```
+
+Then add to the end (choose your theme):
+```bash
+/usr/local/bin/FireMotD -t modern
+```
+
 ### On Nagios Exchange
 
 https://exchange.nagios.org/directory/Utilities/FireMotD/details

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ Production ready.
 
 ### How To
 
-Please check https://outsideit.net/generate-motd for more information on how to use this plugin.
+Please check https://outsideit.net/FireMotD/ for more information on how to use this plugin.
 
 ### Help
 
@@ -38,7 +38,7 @@ In case you find a bug or have a feature request, please make an issue on GitHub
 
 ### On Nagios Exchange
 
-https://exchange.nagios.org/directory/Utilities/MotD-Generator/details
+https://exchange.nagios.org/directory/Utilities/FireMotD/details
 
 ### Copyright
 

--- a/readme.md
+++ b/readme.md
@@ -90,7 +90,10 @@ sudo make bash_completion
 ### Crontab example 
 
 This is an example on how to update the System Update Info daily.
+
 This will update the /var/tmp/updatecount.txt file for later access.
+
+Root privilege is required for this operation.
 
 To edit root's crontab:
 ```bash

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,57 @@ Please check https://outsideit.net/FireMotD/ for more information on how to use 
 
 In case you find a bug or have a feature request, please make an issue on GitHub.
 
+### Usage Help
+
+```
+$ FireMotD --help
+/usr/local/bin/FireMotD v5.02.160528
+
+Usage: /usr/local/bin/FireMotD <-t theme> [UhCVv]
+
+Options:
+  -h | --help        Shows this help and exits
+  -v | --verbose     Verbose mode (shows messages)
+  -V | --version     Shows version information and exits
+  -t | --theme       Shows Motd info on screen, based on the chosen theme
+  -C | --colortest   Prints color test to screen
+  -U | --updates     Checks updates and prints to stdout
+  -s | --saveupdates Check updates and saves to disk
+                     (same as /usr/local/bin/FireMotD -U > /var/tmp/updatecount.txt)
+
+Available Themes:
+  -t original
+  -t modern
+  -t red
+  -t blue
+  -t html
+  -t blank
+
+Examples:
+  /usr/local/bin/FireMotD -t original
+  /usr/local/bin/FireMotD --theme Modern
+  /usr/local/bin/FireMotD --colortest
+  /usr/local/bin/FireMotD --saveupdates
+
+Note:
+  Some functionalities may require superuser priviledges. Eg. check for updates.
+  Please try doing sudo /usr/local/bin/FireMotD if you have problems.
+```
+
+### System Install
+
+You need to have `make` installed on the system.
+
+Then to install to /usr/local/bin:
+```bash
+sudo make install
+```
+
+To install bash_completion (with TAB):
+```bash
+sudo make bash_completion
+```
+
 ### On Nagios Exchange
 
 https://exchange.nagios.org/directory/Utilities/FireMotD/details

--- a/readme.md
+++ b/readme.md
@@ -89,11 +89,9 @@ sudo make bash_completion
 
 ### Crontab example 
 
-This is an example on how to update the System Update Info daily.
-
-This will update the /var/tmp/updatecount.txt file for later access.
-
-Root privilege is required for this operation.
+This is an example on how to update the System Update Info daily.  
+This will update the /var/tmp/updatecount.txt file for later access.  
+Root privilege is required for this operation.  
 
 To edit root's crontab:
 ```bash

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ In case you find a bug or have a feature request, please make an issue on GitHub
 
 ```
 $ FireMotD --help
-/usr/local/bin/FireMotD v5.02.160528
+/usr/local/bin/FireMotD v5.03.160624
 
 Usage: /usr/local/bin/FireMotD <-t theme> [UhCVv]
 


### PR DESCRIPTION
- Added some extra options:
```
Options:
  -h | --help        Shows this help and exits
  -v | --verbose     Verbose mode (shows messages)
  -V | --version     Shows version information and exits
  -t | --theme       Shows Motd info on screen, based on the chosen theme
  -C | --colortest   Prints color test to screen
  -U | --updates     Checks updates and prints to stdout
  -s | --saveupdates Check updates and saves to disk
                     (same as /usr/local/bin/FireMotD -U > /var/tmp/updatecount.txt)
```

- Created Makefile for easier system install.
- Updated readme.md (broken links and extra info).
- Created bash_completion.d/FireMotD Bash auto completion file.
- Some extra parameter validation added.
- Options --updates and --saveupdates now check if running under root UID (maybe this is needed only in Debian? need to check that).
- Corrected --colortest to reset the color to white after running (everything was blue after that).