### PR TITLE
Fix for ubuntu showing "DISTRIB_ID=Ubuntu"

### DIFF
--- a/FireMotD
+++ b/FireMotD
@@ -98,6 +98,8 @@ GatherInfo () {
         OsVersion="$(cat /etc/os-release | sed -n 4p | sed 's/PRETTY_NAME="//' | sed 's/ (.*//')"
     elif [[ "$OsVersion" == *"Raspbian"* ]] ; then
         OsVersion="$(cat /etc/*release | head -n 1 | sed 's/.*"\(.*\)"[^"]*$/\1/')"
+    elif [[ "$OsVersion" == *"Ubuntu"* ]] ; then
+        OsVersion="$(cat /etc/*release | sed -n 9p | sed 's/PRETTY_NAME="//' | sed 's/"//')"
     elif [[ "$OsVersion" == *"PRETTY_NAME"* ]] ; then
         OsVersion="$(cat /etc/*release | head -n 1 | cut -f2 -d'"')"
     fi

--- a/FireMotD
+++ b/FireMotD
@@ -100,7 +100,7 @@ GatherInfo () {
         OsVersion="$(cat /etc/*release | head -n 1 | sed 's/.*"\(.*\)"[^"]*$/\1/')"
     elif [[ "$OsVersion" == *"Ubuntu"* ]] ; then
         OsVersion="$(cat /etc/*release | sed -n 9p | sed 's/PRETTY_NAME="//' | sed 's/"//')"
-    elif [[ "$OsVersion" == *"PRETTY_NAME"* ]] ; then
+    elif [[ "$OsVersion" == *"DISTRIB_DESCRIPTION"* ]] ; then
         OsVersion="$(cat /etc/*release | head -n 1 | cut -f2 -d'"')"
     fi
     IpPath="$(which ip 2>/dev/null)"


### PR DESCRIPTION
Ubuntu was showing DISTRIB_ID=Ubuntu instead of "Ubuntu 16.04 LTS"
This patch fixes it.

It might be worth doing a grep for "PRETTY_NAME" instead of relying on line numbers, as they might change between releases.