### PR TITLE
Fix raspberry mismatch, grep coloring, no swap

### DIFF
--- a/FireMotD
+++ b/FireMotD
@@ -221,7 +221,7 @@ GatherInfo () {
     SwapTotalB="$(cat /proc/meminfo | grep SwapTotal | awk {'print $2'})"
     SwapUsedB="$(expr $SwapTotalB - $SwapFreeB)"
     SwapFree="$(printf "%0.2f\n" $(bc -q <<< scale=2\;$SwapFreeB/1024/1024))"
-    SwapFreePerc=$(echo "scale=2; $SwapFreeB*100/$SwapTotalB" | bc)
+    SwapFreePerc=$(echo "scale=2; $SwapFreeB*100/$SwapTotalB" | bc  &> /dev/null)
     SwapFreePerc=$(echo $(LC_NUMERIC=C printf "%.0f" $SwapFreePerc))
     SwapUsed="$(printf "%0.2f\n" $(bc -q <<< scale=2\;$SwapUsedB/1024/1024))"
     SwapUsedPerc=$(echo "100-$SwapFreePerc" | bc)

--- a/FireMotD
+++ b/FireMotD
@@ -180,9 +180,9 @@ GatherInfo () {
     UptimeMinutes=$(awk '{print int(($1%3600)/60)}' /proc/uptime)
     UptimeSeconds=$(awk '{print int($1%60)}' /proc/uptime)
     Dmesg="$(dmesg)"
-    Dmi="$(echo "$Dmesg" | grep "DMI:")"
-    Rasp="$(echo "$Dmesg" | grep "Rasp")"
-    Xen="$(echo "$Dmesg" | grep -i 'xen version')"
+    Dmi="$(echo "$Dmesg" | GREP_OPTIONS= \grep "DMI:")"
+    Rasp="$(echo "$Dmesg" | GREP_OPTIONS= \grep "Raspberry")"
+    Xen="$(echo "$Dmesg" | GREP_OPTIONS= \grep -i 'xen version')"
     if [[ "$Dmi" = *"QEMU"* ]] ; then
         Platform="$(echo "$Dmi" | sed 's/^.*QEMU/QEMU/' | sed 's/, B.*//')"
     elif [[ "$Dmi" = *"VMware"* ]] ; then


### PR DESCRIPTION
Fixes #15 and #17

* "Rasp" was replaced by "Raspberry", which should be safe.
* Unaliases grep and unsets GREP_OPTIONS to remove coloring
* Masquerade bc "Divide by zero" if no Swap available