### PR TITLE
fix for swap calculation problem

### DIFF
--- a/FireMotD
+++ b/FireMotD
@@ -238,7 +238,7 @@ GatherInfo () {
     SwapTotalB="$(cat /proc/meminfo | grep SwapTotal | awk {'print $2'})"
     SwapUsedB="$(expr $SwapTotalB - $SwapFreeB)"
     SwapFree="$(printf "%0.2f\n" $(bc -q <<< scale=2\;$SwapFreeB/1024/1024))"
-    SwapFreePerc=$(echo "scale=2; $SwapFreeB*100/$SwapTotalB" | bc  &> /dev/null)
+    SwapFreePerc=$(echo "scale=2; $SwapFreeB*100/$SwapTotalB" | bc  2> /dev/null)
     SwapFreePerc=$(echo $(LC_NUMERIC=C printf "%.0f" $SwapFreePerc))
     SwapUsed="$(printf "%0.2f\n" $(bc -q <<< scale=2\;$SwapUsedB/1024/1024))"
     SwapUsedPerc=$(echo "100-$SwapFreePerc" | bc)


### PR DESCRIPTION
Hi,
This very small fix, as the &> redirects everything including the stdout, so the variable becomes empty and the swap usage calculation is consequently wrong.
Regards,
Yannick
