### PR TITLE
fix '-no-headers' typo in the ps flags

### DIFF
--- a/FireMotD
+++ b/FireMotD
@@ -260,7 +260,7 @@ GatherInfo () {
     UpdateCount="Unknown"
     [[ -f $UpdateFile ]] && UpdateCount="$(cat $UpdateFile)"
     SessionCount="$(who | grep -c "$USER")"
-    ProcessCount="$(ps -Afl -no-headers | wc -l)"
+    ProcessCount="$(ps -A --no-headers | wc -l)"
     SysctlPath="$(which sysctl 2>/dev/null)"
     WriteLog Verbose Info "IpPath: $IpPath"
     if [ -z "$SysctlPath" ] ; then


### PR DESCRIPTION
... and simplify options (`-Afl`) passed to `ps` (down to just `-A`) since we're just passing the output straight off to `wc -l` anyways for a count.

`-f` causes the command arguments to be printed.
```
user@host:~$ ps -f
UID        PID  PPID  C STIME TTY          TIME CMD
user    12572  1754  0 02:51 pts/5    00:00:00 -bash
user    13344 12572  0 02:58 pts/5    00:00:00 ps -f
```
`-l` Long Format.
```
user@host:~$ ps
  PID TTY          TIME CMD
12572 pts/5    00:00:00 bash
13170 pts/5    00:00:00 ps

user@host:~$ ps -l
F S   UID   PID  PPID  C PRI  NI ADDR SZ WCHAN  TTY          TIME CMD
0 S  1000 12572  1754  0  80   0 -  5329 wait   pts/5    00:00:00 bash
0 R  1000 13173 12572  0  80   0 -  7290 -      pts/5    00:00:00 ps
```

...neither are needed and possibly may result in unnecessary load on smaller devices ☹️ .