### PR TITLE
Add second IP address parsing command

### DIFF
--- a/FireMotD
+++ b/FireMotD
@@ -165,6 +165,12 @@ GatherInfo () {
     fi
     if [ ! -z $IpPath ] ; then
         IpAddress="$(${IpPath} route get 8.8.8.8 | head -1 | cut -d' ' -f8)"
+        if [[ ! $IpAddress =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            IpAddress="$(${IpPath} route get 8.8.8.8 | head -1 | awk -F' ' '{print $(NF)}')"
+        fi
+        if [[ ! $IpAddress =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            IpAddress="Unable to parse ip. Please debug."
+        fi
     else
         IpAddress="Unable to use ip route. Please debug."
     fi


### PR DESCRIPTION
Closes #21 

This should help find the IP Address on systems where `f8` doesn't work. I've also added a simple validation.

@dimon222 and @a2mj could you please test?
Just execute:
```
/sbin/ip route get 8.8.8.8 | head -1 | awk -F' ' '{print $(NF)}'
```