### PR TITLE
Add randomly delayed cron job and apt update

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -131,14 +131,21 @@ Root privilege is required for this operation.
 sudo crontab -e
 ```
 
-##### Then add this line (updates everyday at 3:03am)
+##### Then add this line
 ```bash
-3 3 * * * /usr/local/bin/FireMotD -S &>/dev/null
+# FireMotD system updates check (randomly execute between 0:00:00 and 5:59:59)
+0 0 * * * root perl -e 'sleep int(rand(21600))' && /bin/bash /opt/FireMotD/FireMotD -S &>/dev/null
 ```
 
-##### Or using the old way
+### Apt configuration to update updates count
+
+On systems with apt (Debian, Ubuntu, ...) add the following configuration lines to refresh the updates count after an apt action (install, remove, ...) was performed.
+
+Create the apt configuration file `/etc/apt/apt.conf.d/15firemotd` containing:
 ```bash
-3 3 * * * /usr/local/bin/FireMotD -U > /var/tmp/updatecount.txt 
+DPkg::Post-Invoke {
+  "if [ -x /usr/local/bin/FireMotD ]; then echo -n 'Updating FireMotD available updates count ... '; /usr/local/bin/FireMotD -S; echo ''; fi";
+};
 ```
 
 ### Adding FireMotD to run on login

--- a/readme.md
+++ b/readme.md
@@ -134,7 +134,7 @@ sudo crontab -e
 ##### Then add this line
 ```bash
 # FireMotD system updates check (randomly execute between 0:00:00 and 5:59:59)
-0 0 * * * root perl -e 'sleep int(rand(21600))' && /bin/bash /opt/FireMotD/FireMotD -S &>/dev/null
+0 0 * * * root perl -e 'sleep int(rand(21600))' && /usr/local/bin/FireMotD -S &>/dev/null
 ```
 
 ### Apt configuration to update updates count


### PR DESCRIPTION
We were contacted by a repository operator because clients around the world were sending coordinated requests in a DDoS like manner. Turns out we were using the cron job which is given as an example in the README, which shoots out `apt update` at 3:03am sharp.

The PR also contains the first halve of what I've suggested in https://github.com/willemdh/FireMotD/issues/18

@willemdh Feel free to modify the PR to reflect your personal preferences